### PR TITLE
Fix component build error

### DIFF
--- a/components/scripts/config.js
+++ b/components/scripts/config.js
@@ -1,11 +1,20 @@
-const fs = require('fs');
 const { tmpdir } = require('os');
 const path = require('path');
 
 const cwd = process.cwd();
 const baseDir = path.resolve(cwd, 'components');
 const tempDir = tmpdir();
-const modules = fs.readdirSync(path.join(baseDir, 'src/'));
+const modules = [
+  'icon',
+  'book',
+  'pagination',
+  'order',
+  'popup',
+  'empty',
+  'fetch_retry_block',
+  'button',
+  'check_box',
+];
 
 module.exports = {
   baseDir,


### PR DESCRIPTION
`components/dist` 폴더가 없는 상황에서 의존하고 있는 컴포넌트가 먼저 빌드되어있지 않으면 빌드에 실패하게 됩니다. 궁극적으로는 index 파일을 생성하는 방식을 바꾸는 것이 좋겠지만, 간단히 빌드 순서를 명시해서 빌드가 성공하도록 수정했습니다.