### PR TITLE
Hold: Refactor CheckBox Component

### DIFF
--- a/components/components.css
+++ b/components/components.css
@@ -2,3 +2,4 @@
 
 /* Import stylesheets for components */
 @import "src/button/index.css";
+@import "src/check_box/index.css";

--- a/components/components.css
+++ b/components/components.css
@@ -2,4 +2,4 @@
 
 /* Import stylesheets for components */
 @import "src/button/index.css";
-@import "src/check_box/index.css";
+@import "src/checkbox/index.css";

--- a/components/scripts/cssBuilder.js
+++ b/components/scripts/cssBuilder.js
@@ -6,7 +6,7 @@ const postcss = require('postcss');
 const atImport = require('postcss-import');
 const cssnext = require('postcss-cssnext');
 const nesting = require('postcss-nesting');
-// const inlineSvg = require('postcss-inline-svg');
+const inlineSvg = require('postcss-inline-svg');
 
 const sourceDir = path.join(__dirname, '../');
 const distDir = path.join(__dirname, '../dist/');
@@ -35,6 +35,10 @@ const plugins = [
       autoprefixer: false,
       nesting: false,
     },
+  }),
+  inlineSvg({
+    path: path.join(sourceDir, '../svg/icons'),
+    removeFill: true,
   }),
 ];
 

--- a/components/src/button/index.css
+++ b/components/src/button/index.css
@@ -1,23 +1,23 @@
 :root {
   /* gray color set */
-  --RUIButton-color-gray10: var(--slategray_10);
-  --RUIButton-color-gray20: var(--slategray_20);
-  --RUIButton-color-gray50: var(--slategray_50);
-  --RUIButton-color-gray60: var(--slategray_60);
-  --RUIButton-boxShadow-gray20: 0 1px 1px 0 color(var(--RUIButton-color-gray20) alpha(30%));
-  --RUIButton-boxShadow-gray50: 0 1px 1px 0 color(var(--RUIButton-color-gray50) alpha(30%));
+  --THRButton-color-gray10: var(--slategray_10);
+  --THRButton-color-gray20: var(--slategray_20);
+  --THRButton-color-gray50: var(--slategray_50);
+  --THRButton-color-gray60: var(--slategray_60);
+  --THRButton-boxShadow-gray20: 0 1px 1px 0 color(var(--THRButton-color-gray20) alpha(30%));
+  --THRButton-boxShadow-gray50: 0 1px 1px 0 color(var(--THRButton-color-gray50) alpha(30%));
 
   /* blue color set */
-  --RUIButton-color-blue10: var(--dodgerblue_10);
-  --RUIButton-color-blue50: var(--dodgerblue_50);
-  --RUIButton-color-blue60: var(--dodgerblue_60);
-  --RUIButton-boxShadow-blue50: 0 1px 1px 0 color(var(--RUIButton-color-blue50) alpha(30%));
+  --THRButton-color-blue10: var(--dodgerblue_10);
+  --THRButton-color-blue50: var(--dodgerblue_50);
+  --THRButton-color-blue60: var(--dodgerblue_60);
+  --THRButton-boxShadow-blue50: 0 1px 1px 0 color(var(--THRButton-color-blue50) alpha(30%));
 
   /* brown color set */
-  --RUIButton-color-brown10: var(--brown_10);
-  --RUIButton-color-brown50: var(--brown_50);
-  --RUIButton-color-brown60: var(--brown_60);
-  --RUIButton-boxShadow-brown50: 0 1px 1px 0 color(var(--RUIButton-color-brown50) alpha(30%));
+  --THRButton-color-brown10: var(--brown_10);
+  --THRButton-color-brown50: var(--brown_50);
+  --THRButton-color-brown60: var(--brown_60);
+  --THRButton-boxShadow-brown50: 0 1px 1px 0 color(var(--THRButton-color-brown50) alpha(30%));
 }
 
 @keyframes SpinnerRotation {
@@ -48,16 +48,16 @@
   justify-content: center;
   margin: 0;
   padding: 0;
-  border: 1px solid var(--RUIButton-color-gray50);
+  border: 1px solid var(--THRButton-color-gray50);
   border-radius: 4px;
-  background: var(--RUIButton-color-gray50);
+  background: var(--THRButton-color-gray50);
   color: white;
   font-size: 13px;
   font-weight: 700;
   line-height: 2.38em;
   text-align: center;
   white-space: nowrap;
-  box-shadow: var(--RUIButton-boxShadow-gray50);
+  box-shadow: var(--THRButton-boxShadow-gray50);
   cursor: pointer;
   user-select: none;
   vertical-align: baseline;
@@ -122,45 +122,45 @@
 }
 
 .THRButton-outline {
-  border-color: var(--RUIButton-color-gray20);
+  border-color: var(--THRButton-color-gray20);
   background: white;
-  color: var(--RUIButton-color-gray50);
-  box-shadow: var(--RUIButton-boxShadow-gray20);
+  color: var(--THRButton-color-gray50);
+  box-shadow: var(--THRButton-boxShadow-gray20);
   & .THRButton_SVGIcon {
-    fill: var(--RUIButton-color-gray50);
+    fill: var(--THRButton-color-gray50);
   }
 }
 
 .THRButton-spinner {
-  color: var(--RUIButton-color-gray50);
+  color: var(--THRButton-color-gray50);
   &::after {
     background-image: url(var(--Spinner-color-gray));
   }
   & .THRButton_SVGIcon {
-    fill: var(--RUIButton-color-gray50);
+    fill: var(--THRButton-color-gray50);
   }
 }
 
 .THRButton-color-gray {
-  border-color: var(--RUIButton-color-gray60);
-  background: var(--RUIButton-color-gray50);
-  box-shadow: var(--RUIButton-boxShadow-gray50);
+  border-color: var(--THRButton-color-gray60);
+  background: var(--THRButton-color-gray50);
+  box-shadow: var(--THRButton-boxShadow-gray50);
   &.THRButton-outline {
-    border-color: var(--RUIButton-color-gray20);
+    border-color: var(--THRButton-color-gray20);
     background: white;
-    color: var(--RUIButton-color-gray50);
-    box-shadow: var(--RUIButton-boxShadow-gray20);
+    color: var(--THRButton-color-gray50);
+    box-shadow: var(--THRButton-boxShadow-gray20);
     & .THRButton_SVGIcon {
-      fill: var(--RUIButton-color-gray50);
+      fill: var(--THRButton-color-gray50);
     }
   }
   &.THRButton-spinner {
-    color: var(--RUIButton-color-gray50);
+    color: var(--THRButton-color-gray50);
     &::after {
       background-image: url(var(--Spinner-color-gray));
     }
     & .THRButton_SVGIcon {
-      fill: var(--RUIButton-color-gray50);
+      fill: var(--THRButton-color-gray50);
     }
   }
   &.THRButton-outline.THRButton-spinner {
@@ -172,24 +172,24 @@
 }
 
 .THRButton-color-blue {
-  border-color: var(--RUIButton-color-blue60);
-  background: var(--RUIButton-color-blue50);
-  box-shadow: var(--RUIButton-boxShadow-blue50);
+  border-color: var(--THRButton-color-blue60);
+  background: var(--THRButton-color-blue50);
+  box-shadow: var(--THRButton-boxShadow-blue50);
   &.THRButton-outline {
-    border-color: var(--RUIButton-color-blue50);
+    border-color: var(--THRButton-color-blue50);
     background: white;
-    color: var(--RUIButton-color-blue50);
+    color: var(--THRButton-color-blue50);
     & .THRButton_SVGIcon {
-      fill: var(--RUIButton-color-blue50);
+      fill: var(--THRButton-color-blue50);
     }
   }
   &.THRButton-spinner {
-    color: var(--RUIButton-color-blue50);
+    color: var(--THRButton-color-blue50);
     &::after {
       background-image: url(var(--Spinner-color-blue));
     }
     & .THRButton_SVGIcon {
-      fill: var(--RUIButton-color-blue50);
+      fill: var(--THRButton-color-blue50);
     }
   }
   &.THRButton-outline.THRButton-spinner {
@@ -201,24 +201,24 @@
 }
 
 .THRButton-color-brown {
-  border-color: var(--RUIButton-color-brown60);
-  background: var(--RUIButton-color-brown50);
-  box-shadow: var(--RUIButton-boxShadow-brown50);
+  border-color: var(--THRButton-color-brown60);
+  background: var(--THRButton-color-brown50);
+  box-shadow: var(--THRButton-boxShadow-brown50);
   &.THRButton-outline {
-    border-color: var(--RUIButton-color-brown50);
+    border-color: var(--THRButton-color-brown50);
     background: white;
-    color: var(--RUIButton-color-brown50);
+    color: var(--THRButton-color-brown50);
     & .THRButton_SVGIcon {
-      fill: var(--RUIButton-color-brown50);
+      fill: var(--THRButton-color-brown50);
     }
   }
   &.THRButton-spinner {
-    color: var(--RUIButton-color-brown50);
+    color: var(--THRButton-color-brown50);
     &::after {
       background-image: url(var(--Spinner-color-brown));
     }
     & .THRButton_SVGIcon {
-      fill: var(--RUIButton-color-brown50);
+      fill: var(--THRButton-color-brown50);
     }
   }
   &.THRButton-outline.THRButton-spinner {
@@ -232,63 +232,63 @@
 /* active, hover color */
 .THRButton:not(:disabled):active,
 .inputMethod-mouse .THRButton:not(:disabled):hover { /* wrapper의 class name 이 inputMethod-mouse 일 때에만 hover 적용 */
-  background: var(--RUIButton-color-gray60);
+  background: var(--THRButton-color-gray60);
   transition: background .2s, color .2s;
 
   & .THRButton_SVGIcon {
     transition: fill .3s;
   }
   &.THRButton-color-gray {
-    background: var(--RUIButton-color-gray60);
+    background: var(--THRButton-color-gray60);
     &.THRButton-outline {
-      background: var(--RUIButton-color-gray10);
+      background: var(--THRButton-color-gray10);
     }
   }
   &.THRButton-color-blue {
-    background: var(--RUIButton-color-blue60);
+    background: var(--THRButton-color-blue60);
     &.THRButton-outline {
-      background: var(--RUIButton-color-blue10);
+      background: var(--THRButton-color-blue10);
     }
   }
   &.THRButton-color-brown {
-    background: var(--RUIButton-color-brown60);
+    background: var(--THRButton-color-brown60);
     &.THRButton-outline {
-      background: var(--RUIButton-color-brown10);
+      background: var(--THRButton-color-brown10);
     }
   }
   &.THRButton-spinner.THRButton-color-gray {
-    color: var(--RUIButton-color-gray60);
+    color: var(--THRButton-color-gray60);
     & .THRButton_SVGIcon {
-      fill: var(--RUIButton-color-gray60);
+      fill: var(--THRButton-color-gray60);
     }
     &.THRButton-outline {
-      color: var(--RUIButton-color-gray10);
+      color: var(--THRButton-color-gray10);
       & .THRButton_SVGIcon {
-        fill: var(--RUIButton-color-gray10);
+        fill: var(--THRButton-color-gray10);
       }
     }
   }
   &.THRButton-spinner.THRButton-color-blue {
-    color: var(--RUIButton-color-blue60);
+    color: var(--THRButton-color-blue60);
     & .THRButton_SVGIcon {
-      fill: var(--RUIButton-color-blue60);
+      fill: var(--THRButton-color-blue60);
     }
     &.THRButton-outline {
-      color: var(--RUIButton-color-blue10);
+      color: var(--THRButton-color-blue10);
       & .THRButton_SVGIcon {
-        fill: var(--RUIButton-color-blue10);
+        fill: var(--THRButton-color-blue10);
       }
     }
   }
   &.THRButton-spinner.THRButton-color-brown {
-    color: var(--RUIButton-color-brown60);
+    color: var(--THRButton-color-brown60);
     & .THRButton_SVGIcon {
-      fill: var(--RUIButton-color-brown60);
+      fill: var(--THRButton-color-brown60);
     }
     &.THRButton-outline {
-      color: var(--RUIButton-color-brown10);
+      color: var(--THRButton-color-brown10);
       & .THRButton_SVGIcon {
-        fill: var(--RUIButton-color-brown10);
+        fill: var(--THRButton-color-brown10);
       }
     }
   }

--- a/components/src/check_box/README.md
+++ b/components/src/check_box/README.md
@@ -1,8 +1,0 @@
-```js
-<>
-  <CheckBox checked={false} onChange={() => {}}>리디북스</CheckBox><br />
-  <CheckBox checked={false} disabled onChange={() => {}}>리디북스</CheckBox><br />
-  <CheckBox checked onChange={() => {}}>리디북스</CheckBox><br />
-  <CheckBox checked disabled onChange={() => {}}>리디북스</CheckBox><br />
-</>
-```

--- a/components/src/check_box/index.css
+++ b/components/src/check_box/index.css
@@ -1,0 +1,96 @@
+:root {
+  --RUIInputLabel-defaultStyle: {
+    @apply --reset-appearance;
+
+    display: inline-block;
+    position: relative;
+    padding-left: calc(var(--RUIInput-size) + .6em);
+    color: var(--slategray_60);
+    font-size: 13px;
+    font-weight: 400;
+    line-height: var(--RUIInput-size);
+    cursor: pointer;
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+    transition: color .2s;
+  }
+
+  --RUIInput_IconWrapper: {
+    box-sizing: border-box;
+    display: block;
+    position: absolute;
+    top: -.1em;
+    left: 0;
+    width: var(--RUIInput-size);
+    height: var(--RUIInput-size);
+    border: 1px solid var(--slategray_20);
+    background: white;
+    content: '';
+    transition: border-color .2s;
+  }
+
+  --RUIInput_Icon: {
+    display: block;
+    position: absolute;
+    top: calc(var(--RUIInput-size) / 2 - .1em);
+    left: calc(var(--RUIInput-size) / 2);
+    transform: translate(-50%, -50%);
+    visibility: hidden;
+  }
+}
+
+.RUICheckBox {
+  @apply --reset-font;
+  @apply --reset-layout;
+  @apply --reset-appearance;
+}
+
+.RUICheckBox_Input {
+  @apply --reset-appearance;
+  @apply --display-hidden;
+}
+
+.RUICheckBox_Label {
+  vertical-align: top;
+  @apply --RUIInputLabel-defaultStyle;
+  @nest .RUICheckBox_Input:checked + & {
+    color: var(--slategray_90);
+  }
+  @nest .RUICheckBox_Input:disabled + & {
+    color: var(--slategray_20);
+    cursor: default;
+  }
+}
+
+.RUICheckBox_Label::before {
+  border-radius: 3px;
+  @apply --RUIInput_IconWrapper;
+  @nest .RUICheckBox_Input:focus + .RUICheckBox_Label &,
+  .RUICheckBox_Input:hover + .RUICheckBox_Label & {
+    @apply --RUIFormElement-focus;
+  }
+  @nest .RUICheckBox_Input:focus + & {
+    border-color: var(--dodgerblue_50);
+    box-shadow: 0 0 0 3px var(--dodgerblue_10);
+  }
+  @nest .RUICheckBox_Input:checked + & {
+    border-color: var(--dodgerblue_60);
+    background: var(--dodgerblue_50);
+  }
+  @nest .RUICheckBox_Input:disabled + & {
+    @apply --RUIFormElement-disabled;
+  }
+}
+
+.RUICheckBox_SVGIcon {
+  width: .77em;
+  height: .77em;
+  fill: white;
+  @apply --RUIInput_Icon;
+  @nest .RUICheckBox_Input:checked + .RUICheckBox_Label & {
+    visibility: visible;
+  }
+  @nest .RUICheckBox_Input:checked:disabled + .RUICheckBox_Label & {
+    visibility: visible;
+    fill: var(--slategray_20);
+  }
+}

--- a/components/src/checkbox/README.md
+++ b/components/src/checkbox/README.md
@@ -1,8 +1,8 @@
 ```js
 <>
-  <Checkbox checked={false} onChange={() => {}}>리디북스</Checkbox><br />
-  <Checkbox checked={false} disabled onChange={() => {}}>리디북스</Checkbox><br />
-  <Checkbox checked onChange={() => {}}>리디북스</Checkbox><br />
-  <Checkbox checked disabled onChange={() => {}}>리디북스</Checkbox><br />
+  <Checkbox /><br />
+  <Checkbox disabled /><br />
+  <Checkbox checked onChange={() => {}} /><br />
+  <Checkbox checked disabled onChange={() => {}} /><br />
 </>
 ```

--- a/components/src/checkbox/README.md
+++ b/components/src/checkbox/README.md
@@ -1,0 +1,8 @@
+```js
+<>
+  <Checkbox checked={false} onChange={() => {}}>리디북스</Checkbox><br />
+  <Checkbox checked={false} disabled onChange={() => {}}>리디북스</Checkbox><br />
+  <Checkbox checked onChange={() => {}}>리디북스</Checkbox><br />
+  <Checkbox checked disabled onChange={() => {}}>리디북스</Checkbox><br />
+</>
+```

--- a/components/src/checkbox/index.css
+++ b/components/src/checkbox/index.css
@@ -1,5 +1,5 @@
 :root {
-  --THRCheckbox-size: 16px;
+  --THRCheckbox-size: 18px;
   --THRCheckbox-iconSize: 10px;
   --THRCheckbox-icon: 'check_1.svg';
 }
@@ -17,17 +17,16 @@
   }
 
   &::after {
-    display: flex;
-    content: svg-load(var(--THRCheckbox-icon), fill=#fff, width=var(--THRCheckbox-iconSize), height=var(--THRCheckbox-iconSize));
-    justify-content: center;
-    align-items: center;
-
+    box-sizing: border-box;
+    display: inline-block;
+    content: "\00a0";
     width: var(--THRCheckbox-size);
     height: var(--THRCheckbox-size);
     border: 1px solid var(--slategray_20);
     border-radius: 3px;
     background: #fff;
-    line-height: 0;
+    text-align: center;
+    line-height: var(--THRCheckbox-size);
     transition: border-color .2s, background-color .2s, box-shadow .2s;
   }
 
@@ -42,12 +41,16 @@
   }
 
   &:checked::after {
+    content: svg-load(var(--THRCheckbox-icon), fill=#fff, width=var(--THRCheckbox-iconSize), height=var(--THRCheckbox-iconSize));
     border-color: var(--dodgerblue_60);
     background: var(--dodgerblue_50);
   }
 
   &:disabled::after {
     @apply --THRFormElement-disabled;
+  }
+
+  &:disabled:checked::after {
     content: svg-load(var(--THRCheckbox-icon), fill=var(--slategray_20), width=var(--THRCheckbox-iconSize), height=var(--THRCheckbox-iconSize));
   }
 }

--- a/components/src/checkbox/index.css
+++ b/components/src/checkbox/index.css
@@ -1,5 +1,5 @@
 :root {
-  --THRCheckbox-size: 18px;
+  --THRCheckbox-size: 16px;
   --THRCheckbox-iconSize: 10px;
   --THRCheckbox-icon: 'check_1.svg';
 }
@@ -27,6 +27,7 @@
     border: 1px solid var(--slategray_20);
     border-radius: 3px;
     background: #fff;
+    line-height: 0;
     transition: border-color .2s, background-color .2s;
   }
 

--- a/components/src/checkbox/index.css
+++ b/components/src/checkbox/index.css
@@ -1,95 +1,95 @@
 :root {
-  --RUIInputLabel-defaultStyle: {
+  --THRInputLabel-defaultStyle: {
     @apply --reset-appearance;
 
     display: inline-block;
     position: relative;
-    padding-left: calc(var(--RUIInput-size) + .6em);
+    padding-left: calc(var(--THRInput-size) + .6em);
     color: var(--slategray_60);
     font-size: 13px;
     font-weight: 400;
-    line-height: var(--RUIInput-size);
+    line-height: var(--THRInput-size);
     cursor: pointer;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
     transition: color .2s;
   }
 
-  --RUIInput_IconWrapper: {
+  --THRInput_IconWrapper: {
     box-sizing: border-box;
     display: block;
     position: absolute;
     top: -.1em;
     left: 0;
-    width: var(--RUIInput-size);
-    height: var(--RUIInput-size);
+    width: var(--THRInput-size);
+    height: var(--THRInput-size);
     border: 1px solid var(--slategray_20);
     background: white;
     content: '';
     transition: border-color .2s;
   }
 
-  --RUIInput_Icon: {
+  --THRInput_Icon: {
     display: block;
     position: absolute;
-    top: calc(var(--RUIInput-size) / 2 - .1em);
-    left: calc(var(--RUIInput-size) / 2);
+    top: calc(var(--THRInput-size) / 2 - .1em);
+    left: calc(var(--THRInput-size) / 2);
     transform: translate(-50%, -50%);
     visibility: hidden;
   }
 }
 
-.RUICheckbox {
+.THRCheckbox {
   @apply --reset-font;
   @apply --reset-layout;
   @apply --reset-appearance;
 }
 
-.RUICheckbox_Input {
+.THRCheckbox_Input {
   @apply --reset-appearance;
   @apply --display-hidden;
 }
 
-.RUICheckbox_Label {
+.THRCheckbox_Label {
   vertical-align: top;
-  @apply --RUIInputLabel-defaultStyle;
-  @nest .RUICheckbox_Input:checked + & {
+  @apply --THRInputLabel-defaultStyle;
+  @nest .THRCheckbox_Input:checked + & {
     color: var(--slategray_90);
   }
-  @nest .RUICheckbox_Input:disabled + & {
+  @nest .THRCheckbox_Input:disabled + & {
     color: var(--slategray_20);
     cursor: default;
   }
 }
 
-.RUICheckbox_Label::before {
+.THRCheckbox_Label::before {
   border-radius: 3px;
-  @apply --RUIInput_IconWrapper;
-  @nest .RUICheckbox_Input:focus + .RUICheckbox_Label &,
-  .RUICheckbox_Input:hover + .RUICheckbox_Label & {
-    @apply --RUIFormElement-focus;
+  @apply --THRInput_IconWrapper;
+  @nest .THRCheckbox_Input:focus + .THRCheckbox_Label &,
+  .THRCheckbox_Input:hover + .THRCheckbox_Label & {
+    @apply --THRFormElement-focus;
   }
-  @nest .RUICheckbox_Input:focus + & {
+  @nest .THRCheckbox_Input:focus + & {
     border-color: var(--dodgerblue_50);
     box-shadow: 0 0 0 3px var(--dodgerblue_10);
   }
-  @nest .RUICheckbox_Input:checked + & {
+  @nest .THRCheckbox_Input:checked + & {
     border-color: var(--dodgerblue_60);
     background: var(--dodgerblue_50);
   }
-  @nest .RUICheckbox_Input:disabled + & {
-    @apply --RUIFormElement-disabled;
+  @nest .THRCheckbox_Input:disabled + & {
+    @apply --THRFormElement-disabled;
   }
 }
 
-.RUICheckbox_SVGIcon {
+.THRCheckbox_SVGIcon {
   width: .77em;
   height: .77em;
   fill: white;
-  @apply --RUIInput_Icon;
-  @nest .RUICheckbox_Input:checked + .RUICheckbox_Label & {
+  @apply --THRInput_Icon;
+  @nest .THRCheckbox_Input:checked + .THRCheckbox_Label & {
     visibility: visible;
   }
-  @nest .RUICheckbox_Input:checked:disabled + .RUICheckbox_Label & {
+  @nest .THRCheckbox_Input:checked:disabled + .THRCheckbox_Label & {
     visibility: visible;
     fill: var(--slategray_20);
   }

--- a/components/src/checkbox/index.css
+++ b/components/src/checkbox/index.css
@@ -1,96 +1,52 @@
 :root {
-  --THRInputLabel-defaultStyle: {
-    @apply --reset-appearance;
-
-    display: inline-block;
-    position: relative;
-    padding-left: calc(var(--THRInput-size) + .6em);
-    color: var(--slategray_60);
-    font-size: 13px;
-    font-weight: 400;
-    line-height: var(--THRInput-size);
-    cursor: pointer;
-    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-    transition: color .2s;
-  }
-
-  --THRInput_IconWrapper: {
-    box-sizing: border-box;
-    display: block;
-    position: absolute;
-    top: -.1em;
-    left: 0;
-    width: var(--THRInput-size);
-    height: var(--THRInput-size);
-    border: 1px solid var(--slategray_20);
-    background: white;
-    content: '';
-    transition: border-color .2s;
-  }
-
-  --THRInput_Icon: {
-    display: block;
-    position: absolute;
-    top: calc(var(--THRInput-size) / 2 - .1em);
-    left: calc(var(--THRInput-size) / 2);
-    transform: translate(-50%, -50%);
-    visibility: hidden;
-  }
+  --THRCheckbox-size: 18px;
+  --THRCheckbox-iconSize: 10px;
+  --THRCheckbox-icon: 'check_1.svg';
 }
 
 .THRCheckbox {
   @apply --reset-font;
   @apply --reset-layout;
   @apply --reset-appearance;
-}
 
-.THRCheckbox_Input {
-  @apply --reset-appearance;
-  @apply --display-hidden;
-}
+  cursor: pointer;
+  outline: none;
 
-.THRCheckbox_Label {
-  vertical-align: top;
-  @apply --THRInputLabel-defaultStyle;
-  @nest .THRCheckbox_Input:checked + & {
-    color: var(--slategray_90);
+  &:disabled {
+    cursor: inherit;
   }
-  @nest .THRCheckbox_Input:disabled + & {
-    color: var(--slategray_20);
-    cursor: default;
-  }
-}
 
-.THRCheckbox_Label::before {
-  border-radius: 3px;
-  @apply --THRInput_IconWrapper;
-  @nest .THRCheckbox_Input:focus + .THRCheckbox_Label &,
-  .THRCheckbox_Input:hover + .THRCheckbox_Label & {
+  &::after {
+    display: flex;
+    content: svg-load(var(--THRCheckbox-icon), fill=#fff, width=var(--THRCheckbox-iconSize), height=var(--THRCheckbox-iconSize));
+    justify-content: center;
+    align-items: center;
+
+    width: var(--THRCheckbox-size);
+    height: var(--THRCheckbox-size);
+    border: 1px solid var(--slategray_20);
+    border-radius: 3px;
+    background: #fff;
+    transition: border-color .2s, background-color .2s;
+  }
+
+  &:focus::after,
+  &:hover::after {
     @apply --THRFormElement-focus;
   }
-  @nest .THRCheckbox_Input:focus + & {
+
+  &:focus::after {
     border-color: var(--dodgerblue_50);
     box-shadow: 0 0 0 3px var(--dodgerblue_10);
   }
-  @nest .THRCheckbox_Input:checked + & {
+
+  &:checked::after {
     border-color: var(--dodgerblue_60);
     background: var(--dodgerblue_50);
   }
-  @nest .THRCheckbox_Input:disabled + & {
-    @apply --THRFormElement-disabled;
-  }
-}
 
-.THRCheckbox_SVGIcon {
-  width: .77em;
-  height: .77em;
-  fill: white;
-  @apply --THRInput_Icon;
-  @nest .THRCheckbox_Input:checked + .THRCheckbox_Label & {
-    visibility: visible;
-  }
-  @nest .THRCheckbox_Input:checked:disabled + .THRCheckbox_Label & {
-    visibility: visible;
-    fill: var(--slategray_20);
+  &:disabled::after {
+    @apply --THRFormElement-disabled;
+    content: svg-load(var(--THRCheckbox-icon), fill=var(--slategray_20), width=var(--THRCheckbox-iconSize), height=var(--THRCheckbox-iconSize));
   }
 }

--- a/components/src/checkbox/index.css
+++ b/components/src/checkbox/index.css
@@ -38,58 +38,58 @@
   }
 }
 
-.RUICheckBox {
+.RUICheckbox {
   @apply --reset-font;
   @apply --reset-layout;
   @apply --reset-appearance;
 }
 
-.RUICheckBox_Input {
+.RUICheckbox_Input {
   @apply --reset-appearance;
   @apply --display-hidden;
 }
 
-.RUICheckBox_Label {
+.RUICheckbox_Label {
   vertical-align: top;
   @apply --RUIInputLabel-defaultStyle;
-  @nest .RUICheckBox_Input:checked + & {
+  @nest .RUICheckbox_Input:checked + & {
     color: var(--slategray_90);
   }
-  @nest .RUICheckBox_Input:disabled + & {
+  @nest .RUICheckbox_Input:disabled + & {
     color: var(--slategray_20);
     cursor: default;
   }
 }
 
-.RUICheckBox_Label::before {
+.RUICheckbox_Label::before {
   border-radius: 3px;
   @apply --RUIInput_IconWrapper;
-  @nest .RUICheckBox_Input:focus + .RUICheckBox_Label &,
-  .RUICheckBox_Input:hover + .RUICheckBox_Label & {
+  @nest .RUICheckbox_Input:focus + .RUICheckbox_Label &,
+  .RUICheckbox_Input:hover + .RUICheckbox_Label & {
     @apply --RUIFormElement-focus;
   }
-  @nest .RUICheckBox_Input:focus + & {
+  @nest .RUICheckbox_Input:focus + & {
     border-color: var(--dodgerblue_50);
     box-shadow: 0 0 0 3px var(--dodgerblue_10);
   }
-  @nest .RUICheckBox_Input:checked + & {
+  @nest .RUICheckbox_Input:checked + & {
     border-color: var(--dodgerblue_60);
     background: var(--dodgerblue_50);
   }
-  @nest .RUICheckBox_Input:disabled + & {
+  @nest .RUICheckbox_Input:disabled + & {
     @apply --RUIFormElement-disabled;
   }
 }
 
-.RUICheckBox_SVGIcon {
+.RUICheckbox_SVGIcon {
   width: .77em;
   height: .77em;
   fill: white;
   @apply --RUIInput_Icon;
-  @nest .RUICheckBox_Input:checked + .RUICheckBox_Label & {
+  @nest .RUICheckbox_Input:checked + .RUICheckbox_Label & {
     visibility: visible;
   }
-  @nest .RUICheckBox_Input:checked:disabled + .RUICheckBox_Label & {
+  @nest .RUICheckbox_Input:checked:disabled + .RUICheckbox_Label & {
     visibility: visible;
     fill: var(--slategray_20);
   }

--- a/components/src/checkbox/index.css
+++ b/components/src/checkbox/index.css
@@ -28,7 +28,7 @@
     border-radius: 3px;
     background: #fff;
     line-height: 0;
-    transition: border-color .2s, background-color .2s;
+    transition: border-color .2s, background-color .2s, box-shadow .2s;
   }
 
   &:focus::after,

--- a/components/src/checkbox/index.tsx
+++ b/components/src/checkbox/index.tsx
@@ -2,21 +2,15 @@ import classNames from 'classnames';
 import * as React from 'react';
 
 export interface CheckboxProps {
-  checked: boolean;
   className?: string;
   component?: React.ReactType<CheckboxProps>;
-  disabled?: boolean;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   [extraKey: string]: any;
 }
 
 export const Checkbox: React.SFC<CheckboxProps> = (props) => {
   const {
-    checked,
     className,
     component,
-    disabled,
-    onChange,
     ...extraProps,
   } = props;
 
@@ -26,9 +20,6 @@ export const Checkbox: React.SFC<CheckboxProps> = (props) => {
     <Wrapper
       type="checkbox"
       className={classNames('THRCheckbox', className)}
-      checked={checked}
-      disabled={disabled}
-      onChange={onChange}
       {...extraProps}
     />
   );

--- a/components/src/checkbox/index.tsx
+++ b/components/src/checkbox/index.tsx
@@ -1,38 +1,35 @@
-import { Icon } from '@ridi/rsg';
+import classNames from 'classnames';
 import * as React from 'react';
 
 export interface CheckboxProps {
   checked: boolean;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   className?: string;
+  component?: React.ReactType<CheckboxProps>;
   disabled?: boolean;
-  children?: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  [extraKey: string]: any;
 }
 
 export const Checkbox: React.SFC<CheckboxProps> = (props) => {
   const {
     checked,
-    onChange,
-    disabled,
-    children,
     className,
+    component,
+    disabled,
+    onChange,
+    ...extraProps,
   } = props;
+
+  const Wrapper = component || 'input';
+
   return (
-    <label className={`THRCheckbox ${className}`}>
-      <input
-        type="checkbox"
-        className="THRCheckbox_Input"
-        checked={checked}
-        disabled={disabled}
-        onChange={onChange}
-      />
-      <span className="THRCheckbox_Label">
-        <Icon
-          name="check_1"
-          className="THRCheckbox_SVGIcon"
-        />
-        {children}
-      </span>
-    </label>
+    <Wrapper
+      type="checkbox"
+      className={classNames('THRCheckbox', className)}
+      checked={checked}
+      disabled={disabled}
+      onChange={onChange}
+      {...extraProps}
+    />
   );
 };

--- a/components/src/checkbox/index.tsx
+++ b/components/src/checkbox/index.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@ridi/rsg';
 import * as React from 'react';
 
-export interface CheckBoxProps {
+export interface CheckboxProps {
   checked: boolean;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   className?: string;
@@ -9,7 +9,7 @@ export interface CheckBoxProps {
   children?: string;
 }
 
-export const CheckBox: React.SFC<CheckBoxProps> = (props) => {
+export const Checkbox: React.SFC<CheckboxProps> = (props) => {
   const {
     checked,
     onChange,
@@ -18,18 +18,18 @@ export const CheckBox: React.SFC<CheckBoxProps> = (props) => {
     className,
   } = props;
   return (
-    <label className={`RUICheckBox ${className}`}>
+    <label className={`RUICheckbox ${className}`}>
       <input
         type="checkbox"
-        className="RUICheckBox_Input"
+        className="RUICheckbox_Input"
         checked={checked}
         disabled={disabled}
         onChange={onChange}
       />
-      <span className="RUICheckBox_Label">
+      <span className="RUICheckbox_Label">
         <Icon
           name="check_1"
-          className="RUICheckBox_SVGIcon"
+          className="RUICheckbox_SVGIcon"
         />
         {children}
       </span>

--- a/components/src/checkbox/index.tsx
+++ b/components/src/checkbox/index.tsx
@@ -18,18 +18,18 @@ export const Checkbox: React.SFC<CheckboxProps> = (props) => {
     className,
   } = props;
   return (
-    <label className={`RUICheckbox ${className}`}>
+    <label className={`THRCheckbox ${className}`}>
       <input
         type="checkbox"
-        className="RUICheckbox_Input"
+        className="THRCheckbox_Input"
         checked={checked}
         disabled={disabled}
         onChange={onChange}
       />
-      <span className="RUICheckbox_Label">
+      <span className="THRCheckbox_Label">
         <Icon
           name="check_1"
-          className="RUICheckbox_SVGIcon"
+          className="THRCheckbox_SVGIcon"
         />
         {children}
       </span>

--- a/components/src/checkbox/index.tsx
+++ b/components/src/checkbox/index.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 export interface CheckboxProps {
   className?: string;
-  component?: React.ReactType<CheckboxProps>;
+  component?: React.ReactType;
   [extraKey: string]: any;
 }
 

--- a/components/variables.css
+++ b/components/variables.css
@@ -28,7 +28,7 @@
   --bookCoverMaxHeight-width180: 281px;
   --bookCoverMaxHeight-width190: 297px;
   --bookCoverMaxHeight-width200: 313px;
-  --RUIInput-size: 1.38em;
+  --THRInput-size: 1.38em;
 
   /* properties */
   --reset-layout: {
@@ -96,16 +96,16 @@
     -webkit-line-clamp: 3;
   }
 
-  --RUIFormElement-focus: {
+  --THRFormElement-focus: {
     border-color: var(--dodgerblue_50);
     box-shadow: 0 0 4px color(var(--dodgerblue_50) alpha(10%));
   }
 
-  --RUIFormElement-hover: {
+  --THRFormElement-hover: {
     border-color: var(--slategray_50);
   }
 
-  --RUIFormElement-disabled: {
+  --THRFormElement-disabled: {
     border-color: var(--slategray_20);
     background: var(--slategray_5);
     color: var(--slategray_20);

--- a/components/variables.css
+++ b/components/variables.css
@@ -46,6 +46,7 @@
 
   --reset-appearance: {
     -webkit-appearance: none;
+    -moz-appearance: none;
     appearance: none;
     border: 0;
   }


### PR DESCRIPTION
https://app.asana.com/0/778578119305199/791325529097311/f

To keep the usage of checkbox in plain HTML, `input` is used as root component directly rather than wrap components with `label`. So `Checkbox` no longer contains any child and `label` need to be used from the outside of `Checkbox`. Maybe we should create `Label` component for styled `label`.

## Changes
- Copy CSS from `stylesheets`
- Rename component from `CheckBox` to `Checkbox`
- Change CSS prefix from `RUI` to `THR`
- Use `input` as root component
- Pass through props and remove redundant props definitions