### PR TITLE
Remove inappropriate generic

### DIFF
--- a/components/src/button/index.tsx
+++ b/components/src/button/index.tsx
@@ -8,7 +8,7 @@ export interface ButtonProps {
   thickBorderWidth?: boolean;
   disabled?: boolean;
   spinner?: boolean;
-  component?: React.ReactType<ButtonProps>;
+  component?: React.ReactType;
   className?: string;
   children?: React.ReactNode;
   onClick?: (e: React.SyntheticEvent<any>) => void;


### PR DESCRIPTION
`React.ReactType<ButtonProps>` forces `element` to have the same interface as `ButtonProps`, which is not intended.