### PR TITLE
Fix incorrect Popup interface

### DIFF
--- a/components/src/Popup/index.tsx
+++ b/components/src/Popup/index.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 export interface PopupProps {
   title: string;
   active: boolean;
-  caution?: React.ReactElement<any>;
+  caution?: React.ReactType;
   tabs?: Array<{
     name: string;
     content: React.ReactElement<any>;


### PR DESCRIPTION
Currently passing string value like the following is not possible:

```jsx
<Popup
   ...
   catuion="asdfads"
/>
```