### PR TITLE
Improve popup styling

### DIFF
--- a/components/src/Popup/index.css
+++ b/components/src/Popup/index.css
@@ -67,11 +67,13 @@
   fill: var(--brown_70);
 }
 
+.RUIPopup_Header {
+  background: #41474c;
+}
 .RUIPopup_Header_Nav {
   position: relative;
   height: 34px;
   padding: 0 10px;
-  background: #41474c;
   border-radius: 3px 3px 0 0;
 }
 .RUIPopup_Title {


### PR DESCRIPTION
<img width="308" alt="screen shot 2018-11-02 at 6 13 29 pm" src="https://user-images.githubusercontent.com/7221609/47905765-3a248780-decb-11e8-9384-c0b2d141a53b.png">

It's not a thing that developer can really notice about, but there is a narrow space at the edge of the header filled in white. The fixed stylesheet fixes this problem.